### PR TITLE
Close Navbar Modal on User Click

### DIFF
--- a/app/views/partials/navbar.ejs
+++ b/app/views/partials/navbar.ejs
@@ -22,3 +22,11 @@
       </ul>
     </div>
   </nav>
+  
+  <script>
+    $(document).ready(function(){
+        $('#navbarNav li a').on('click', function(){
+            $('.navbar-toggler').click()
+        });
+    });
+  </script>


### PR DESCRIPTION
### Descrption

Previously, on mobile devices, this navbar modal could be viewed by a user, but upon selection of an element on the modal. The modal would not automatically close.
![Screen Shot 2021-03-21 at 11 54 49 AM](https://user-images.githubusercontent.com/42784674/111913472-40841180-8a3c-11eb-8bc8-a7a7034f47b3.png)

After this PR, the navigation modal automatically closes upon receiving a user click event.
