### PR TITLE
Fix: Remove Overflow Causing Horizontal Scroll Bar

### DIFF
--- a/app/public/css/main.css
+++ b/app/public/css/main.css
@@ -6,6 +6,7 @@ body, html {
     margin: 0px 0px;
     padding: 0px 0px;
     font-weight: 400;
+    overflow-x: hidden;
 }
 
 a,


### PR DESCRIPTION
### Description

Overflow in the horizontal axis caused overflow. This 1 liner PR makes any horizontal overflow hidden.